### PR TITLE
sc-dev: Simplified analyze stage parallel processing steps and switch…

### DIFF
--- a/hedra/core/graphs/stages/analyze/parallel/process_results_batch.py
+++ b/hedra/core/graphs/stages/analyze/parallel/process_results_batch.py
@@ -1,107 +1,14 @@
 
-
-import asyncio
 import time
-import dill
-import json
 import threading
 import os
 import signal 
 from collections import defaultdict
 from typing import Any, Dict, List
-from hedra.core.hooks.types.base.simple_context import SimpleContext
 from hedra.core.engines.types.common.base_result import BaseResult
-from hedra.core.hooks.types.base.event_graph import EventGraph
-from hedra.core.hooks.types.base.registrar import registrar
-from hedra.core.graphs.stages.base.import_tools import (
-    import_stages,
-    set_stage_hooks
-)
-from hedra.core.graphs.stages.base.stage import Stage
-from hedra.logging import (
-    HedraLogger,
-    LoggerTypes,
-    logging_manager
-)
+from hedra.logging import HedraLogger
 from hedra.reporting.processed_result.processed_results_group import ProcessedResultsGroup
-dill.settings['byref'] = True
 
-async def process_batch(
-        stage: Stage=None,
-        stage_name: str=None, 
-        custom_metric_hook_names: List[str]=[],
-        results_batch: List[BaseResult]=[],
-        metadata_string: str=None
-    ):
-
-        hedra_config_filepath = os.path.join(
-            os.getcwd(),
-            '.hedra.json'
-        )
-
-        hedra_config = {}
-        if os.path.exists(hedra_config_filepath):
-            with open(hedra_config_filepath, 'r') as hedra_config_file:
-                hedra_config = json.load(hedra_config_file)
-
-        logging_config = hedra_config.get('logging', {})
-        logfiles_directory = logging_config.get(
-            'logfiles_directory',
-            os.getcwd()
-        )
-
-        log_level = logging_config.get('log_level', 'info')
-
-        logging_manager.disable(
-            LoggerTypes.DISTRIBUTED,
-            LoggerTypes.DISTRIBUTED_FILESYSTEM
-        )
-
-        logging_manager.update_log_level(log_level)
-        logging_manager.logfiles_directory = logfiles_directory
-
-
-        logger = HedraLogger()
-        logger.initialize()
-        await logger.filesystem.aio.create_logfile('hedra.core.log')
-        await logger.filesystem.aio.create_logfile('hedra.reporting.log')
-
-        logger.filesystem.create_filelogger('hedra.core.log')
-        logger.filesystem.create_filelogger('hedra.reporting.log')
-
-        await logger.filesystem.aio['hedra.core'].info(f'{metadata_string} - Initializing results aggregation')
-
-        start = time.monotonic()
-
-        events =  defaultdict(ProcessedResultsGroup)
-
-        custom_metric_hooks = []
-        for metric_hook_name in custom_metric_hook_names:
-            custom_metric_hook_set = registrar.all.get(metric_hook_name, [])
-            
-            for custom_metric_hook in custom_metric_hook_set:
-                custom_metric_hooks.append(custom_metric_hook)
-
-        for stage_result in results_batch:
-            events[stage_result.name].add(
-                    stage,
-                    stage_result,
-                    stage_name
-                )
-
-        for events_stage_name, events_group in events.items():  
-
-            await logger.filesystem.aio['hedra.reporting'].debug(
-                f'{metadata_string} - Events group - {events_group.events_group_id} - created for Stage - {events_stage_name} - Processed - {events_group.total}'
-            )
-
-            events_group.calculate_partial_group_stats()
-
-        elapsed = time.monotonic() - start
-
-        await logger.filesystem.aio['hedra.core'].info(f'{metadata_string} - Results aggregation complete - Took: {round(elapsed, 2)} seconds')
-
-        return events
 
 
 def process_results_batch(config: Dict[str, Any]):
@@ -112,58 +19,18 @@ def process_results_batch(config: Dict[str, Any]):
     asyncio.set_event_loop(loop)
     
     graph_name = config.get('graph_name')
-    graph_path = config.get('graph_path')
     graph_id = config.get('graph_id')
     source_stage_name = config.get('source_stage_name')
-    source_stage_context = config.get('source_stage_context')
     source_stage_id = config.get('source_stage_id')
 
     thread_id = threading.current_thread().ident
     process_id = os.getpid()
 
-    meetadata_string = f'Graph - {graph_name}:{graph_id} - thread:{thread_id} - process:{process_id} - Stage: {source_stage_name}:{source_stage_id} - '
+    metadata_string = f'Graph - {graph_name}:{graph_id} - thread:{thread_id} - process:{process_id} - Stage: {source_stage_name}:{source_stage_id} - '
 
     stage_name = config.get('analyze_stage_name')
-    custom_metric_hook_names = config.get('analyze_stage_metric_hooks', [])
-    results_batch = config.get('analyze_stage_batched_results', [])
+    results_batch: List[BaseResult] = config.get('analyze_stage_batched_results', [])
 
-    discovered: Dict[str, Stage] = import_stages(graph_path)
-    
-    initialized_stages = {}
-    hooks_by_type = defaultdict(dict)
-    hooks_by_name = {}
-    hooks_by_shortname = defaultdict(dict)
-
-    generated_hooks = {}
-    for stage in discovered.values():
-        stage.context = SimpleContext()
-        initialized_stage =  set_stage_hooks(
-            stage(), 
-            generated_hooks
-        )
-
-        initialized_stages[initialized_stage.name] = initialized_stage
-
-        for hook_type in initialized_stage.hooks:
-
-            for hook in initialized_stage.hooks[hook_type]:
-                hooks_by_type[hook_type][hook.name] = hook
-                hooks_by_name[hook.name] = hook
-                hooks_by_shortname[hook_type][hook.shortname] = hook
-
-    setup_analyze_stage: Stage = initialized_stages.get(stage_name)
-    setup_analyze_stage.context = SimpleContext()
-    setup_analyze_stage.context.update(source_stage_context)
-
-    events_graph = EventGraph(hooks_by_type)
-    events_graph.hooks_by_name = hooks_by_name
-    events_graph.hooks_by_shortname = hooks_by_shortname
-    events_graph.hooks_to_events().assemble_graph().apply_graph_to_events()
-    
-    pipeline_stage = {
-        setup_analyze_stage.name: setup_analyze_stage
-    }
-                
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
@@ -181,27 +48,36 @@ def process_results_batch(config: Dict[str, Any]):
 
     try:
 
-        events = loop.run_until_complete(
-            process_batch(
-                stage=setup_analyze_stage,
-                stage_name=stage_name,
-                custom_metric_hook_names=custom_metric_hook_names,
-                results_batch=results_batch,
-                metadata_string=meetadata_string
+        events =  defaultdict(ProcessedResultsGroup)
+
+        logger = HedraLogger()
+        logger.initialize()
+        logger.filesystem.sync.create_logfile('hedra.core.log')
+        logger.filesystem.sync.create_logfile('hedra.reporting.log')
+        
+        logger.filesystem.sync['hedra.core'].info(f'{metadata_string} - Initializing results aggregation')
+
+        start = time.monotonic()
+
+        for stage_result in results_batch:
+            events[stage_result.name].add(
+                    stage_name,
+                    stage_result,
+                )
+
+        for events_stage_name, events_group in events.items():  
+
+            logger.filesystem.sync['hedra.reporting'].debug(
+                f'{metadata_string} - Events group - {events_group.events_group_id} - created for Stage - {events_stage_name} - Processed - {events_group.total}'
             )
-        )
 
-        context = {}
-        for stage in pipeline_stage.values():                
-            serializable_context = stage.context.as_serializable()
-            context.update({
-                context_key: context_value for context_key, context_value in serializable_context
-            })
+            events_group.calculate_stats()
 
-        return {
-            'events': events,
-            'context': context
-        }
+        elapsed = time.monotonic() - start
+
+        logger.filesystem.sync['hedra.core'].info(f'{metadata_string} - Results aggregation complete - Took: {round(elapsed, 2)} seconds')
+
+        return events
 
     except BrokenPipeError:
 

--- a/hedra/core/graphs/stages/execute/parallel/execute_actions.py
+++ b/hedra/core/graphs/stages/execute/parallel/execute_actions.py
@@ -1,13 +1,10 @@
 import json
-import asyncio
 import threading
 import os
 import time
 import signal
 import dill
 import pickle
-import traceback
-from concurrent.futures import ThreadPoolExecutor
 from collections import defaultdict
 from typing import Dict, Any, List, Union
 from hedra.core.engines.client.config import Config

--- a/hedra/core/graphs/transitions/analyze/analyze_edge.py
+++ b/hedra/core/graphs/transitions/analyze/analyze_edge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import asyncio
 import inspect
+import traceback
 from collections import defaultdict
 from typing import Dict, List, Any
 from hedra.core.hooks.types.base.hook import Hook
@@ -101,6 +102,7 @@ class AnalyzeEdge(BaseEdge[Analyze]):
             self.visited.append(self.source.name)
 
         except Exception as edge_exception:
+            print(traceback.format_exc())
             self.exception = edge_exception
 
         return None, self.destination.stage_type

--- a/hedra/reporting/processed_result/types/base_processed_result.py
+++ b/hedra/reporting/processed_result/types/base_processed_result.py
@@ -25,7 +25,7 @@ class BaseProcessedResult:
 
     def __init__(
         self, 
-        stage: Any, 
+        stage_name: str, 
         result: BaseResult
     ) -> None:
 
@@ -39,7 +39,7 @@ class BaseProcessedResult:
         self.type = result.type
         self.source = result.source
         self.checks: List[List[BaseEvent]] = []
-        self.stage_name = stage.name
+        self.stage = stage_name
 
         self.time = self.timings.get('total', 0)
 
@@ -49,7 +49,6 @@ class BaseProcessedResult:
                 tag.get('value')
             ) for tag in result.tags
         ]
-        self.stage = None
 
 
     @property

--- a/hedra/reporting/processed_result/types/graphql_http2_processed_result.py
+++ b/hedra/reporting/processed_result/types/graphql_http2_processed_result.py
@@ -5,15 +5,34 @@ from hedra.core.engines.types.graphql_http2 import GraphQLHTTP2Result
 
 class GraphQLHTTP2ProcessedResult(HTTP2ProcessedResult):
 
+    __slots__ = (
+        'event_id',
+        'action_id',
+        'url',
+        'ip_addr',
+        'method',
+        'path',
+        'params',
+        'hostname',
+        'status',
+        'headers',
+        'data',
+        'status',
+        'timings',
+        'query'
+    )
+
     def __init__(
         self, 
-        stage: Any, 
+        stage: str, 
         result: GraphQLHTTP2Result
     ) -> None:
         super(GraphQLHTTP2ProcessedResult, self).__init__(
             stage,
             result
         )
+
+        self.query = result.query
 
     def to_dict(self) -> Dict[str, Union[str, int, float]]:
         graphql_result_dict = super().to_dict()

--- a/hedra/reporting/processed_result/types/graphql_processed_result.py
+++ b/hedra/reporting/processed_result/types/graphql_processed_result.py
@@ -4,10 +4,27 @@ from .http_processed_result import HTTPProcessedResult
 
 
 class GraphQLProcessedResult(HTTPProcessedResult):
+    
+    __slots__ = (
+        'event_id',
+        'action_id',
+        'url',
+        'ip_addr',
+        'method',
+        'path',
+        'params',
+        'hostname',
+        'status',
+        'headers',
+        'data',
+        'status',
+        'timings',
+        'query'
+    )
 
     def __init__(
         self, 
-        stage: Any, 
+        stage: str, 
         result: GraphQLResult
     ) -> None:
         super(GraphQLProcessedResult, self).__init__(

--- a/hedra/reporting/processed_result/types/grpc_processed_result.py
+++ b/hedra/reporting/processed_result/types/grpc_processed_result.py
@@ -7,7 +7,7 @@ class GRPCProcessedResult(HTTP2ProcessedResult):
 
     def __init__(
         self, 
-        stage: Any, 
+        stage: str, 
         result: GRPCResult
     ) -> None:
         super(

--- a/hedra/reporting/processed_result/types/http2_processed_result.py
+++ b/hedra/reporting/processed_result/types/http2_processed_result.py
@@ -24,7 +24,7 @@ class HTTP2ProcessedResult(BaseProcessedResult):
 
     def __init__(
         self, 
-        stage: Any, 
+        stage: str, 
         result: HTTP2Result
     ) -> None:
         super(HTTP2ProcessedResult, self).__init__(

--- a/hedra/reporting/processed_result/types/http3_processed_result.py
+++ b/hedra/reporting/processed_result/types/http3_processed_result.py
@@ -7,7 +7,7 @@ class HTTP3ProcessedResult(HTTPProcessedResult):
 
     def __init__(
         self, 
-        stage: Any, 
+        stage: str, 
         result: GraphQLResult
     ) -> None:
         super(HTTP3ProcessedResult, self).__init__(

--- a/hedra/reporting/processed_result/types/http_processed_result.py
+++ b/hedra/reporting/processed_result/types/http_processed_result.py
@@ -23,7 +23,7 @@ class HTTPProcessedResult(BaseProcessedResult):
 
     def __init__(
         self, 
-        stage: Any, 
+        stage: str, 
         result: HTTPResult
     ) -> None:
         super(HTTPProcessedResult, self).__init__(

--- a/hedra/reporting/processed_result/types/playwright_processed_result.py
+++ b/hedra/reporting/processed_result/types/playwright_processed_result.py
@@ -21,7 +21,7 @@ class PlaywrightProcessedResult(BaseProcessedResult):
 
     def __init__(
         self, 
-        stage: Any, 
+        stage: str, 
         result: PlaywrightResult
     ) -> None:
         super(

--- a/hedra/reporting/processed_result/types/task_processed_result.py
+++ b/hedra/reporting/processed_result/types/task_processed_result.py
@@ -8,7 +8,7 @@ class TaskProcessedResult(BaseProcessedResult):
 
     def __init__(
         self, 
-        stage: Any, 
+        stage: str, 
         result: TaskResult
     ) -> None:
         super(

--- a/hedra/reporting/processed_result/types/udp_processed_result.py
+++ b/hedra/reporting/processed_result/types/udp_processed_result.py
@@ -23,7 +23,7 @@ class UDPProcessedResult(BaseProcessedResult):
 
     def __init__(
         self, 
-        stage: Any, 
+        stage: str, 
         result: UDPResult
     ) -> None:
         super(UDPProcessedResult, self).__init__(

--- a/hedra/reporting/processed_result/types/websocket_processed_result.py
+++ b/hedra/reporting/processed_result/types/websocket_processed_result.py
@@ -7,7 +7,7 @@ class WebsocketProcessedResult(HTTPProcessedResult):
 
     def __init__(
         self, 
-        stage: Any, 
+        stage: str, 
         result: WebsocketResult
     ) -> None:
         super(


### PR DESCRIPTION
# Overview

Hedra 0.7.7 corrects the underlying issues with Analyze stage parallelism resulting in both incorrect calculation of statistics during Processed Results Group merging and slowness due to poor use of parallelism.

# Details

Previously Hedra use the batching scheme used for Execute stages to divide the calculation of processed results. This resulted in heavy results aggregation overhead due to CPU thread spawn time, results object serialization/deserialization with pickling, and incorrect results metrics for variance/standard deviation.

Hedra 0.7.7 corrects these issues by adding "by stage" parallelism to Hedra's BatchExecutor. When a stage's Batch Executor has `batch_by_stages` set to `True`, the Batch Executor will instead  provision one worker per stage and execute no batching on stage data provided (submitting all data to the worker assigned to the stage). Hedra 0.7.7 also removes the `merge()` method from the `ProcessedResultsGroup` class as it is no longer needed due to by-stage parallelism.

Finally, a `condition()` hook `check_if_multiple_stages` now runs prior to the `execute_batched_analysis` hook. If this `condition()` hook determines only one stage is to be aggregates, the following `execute_batched_analysis` hook will execute stage results in the main thread.